### PR TITLE
Added new configuration for homeassistant 2022.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,160 @@ sensor:
     qos: 0
 
 ```
+
+## New Home Assistant Configuration
+Please note, starting from Home Assistant version 2022.12.0 the above configuration will not work anymore.
+The MQTT items have now to be `mqtt` configuration. See the [documentation](https://www.home-assistant.io/integrations/binary_sensor.mqtt/#new_format), for more information.
+
+```
+input_number:
+  set_wtw_ventilation_level:
+    name: Set ventilation level
+    initial: 1
+    min: 1
+    max: 3
+    step: 1
+    mode: slider
+
+input_number:
+  set_wtw_temperature:
+    name: Set temperature
+    initial: 20
+    min: 10
+    max: 25
+    step: 1
+    mode: slider
+
+automation:
+  - alias: Ventilation level slider moved in GUI
+    trigger:
+      platform: state
+      entity_id: input_number.set_wtw_ventilation_level
+    action:
+      service: mqtt.publish
+      data_template:
+        topic: house/ventilation/whr930/setventilation
+        retain: false
+        payload: "{{ states('input_number.set_wtw_ventilation_level') | int }}"
+  - alias: Temperature level slider moved in GUI
+    trigger:
+      platform: state
+      entity_id: input_number.set_wtw_temperature
+    action:
+      service: mqtt.publish
+      data_template:
+        topic: house/ventilation/whr930/settemperature
+        retain: false
+        payload: "{{ states('input_number.set_wtw_temperature') | int }}"
+
+customize:
+  sensor.wtw_intake_fan_speed:
+    icon: mdi:fan
+  sensor.wtw_exhaust_fan_speed:
+    icon: mdi:fan
+
+
+mqtt:
+  sensor:
+    - state_topic: "house/ventilation/whr930/filter_state"
+      name: "WTW Filter Status"
+      qos: 0
+    
+    - state_topic: "house/ventilation/whr930/comfort_temp"
+      name: "WTW Comfort Temperature"
+      qos: 0
+      unit_of_measurement: '°C'
+
+
+    - state_topic: "house/ventilation/whr930/comfort_temp"
+      name: "WTW Comfort Temperature"
+      qos: 0
+      unit_of_measurement: '°C'
+
+    - state_topic: "house/ventilation/whr930/outside_air_temp"
+      name: "WTW Outside Temperature"
+      qos: 0
+      unit_of_measurement: '°C'
+
+    - state_topic: "house/ventilation/whr930/supply_air_temp"
+      name: "WTW Supply Temperature"
+      qos: 0
+      unit_of_measurement: '°C'
+
+    - state_topic: "house/ventilation/whr930/return_air_temp"
+      name: "WTW Return Temperature"
+      qos: 0
+      unit_of_measurement: '°C'
+ 
+    - state_topic: "house/ventilation/whr930/exhaust_air_temp"
+      name: "WTW Exhaust Temperature"
+      qos: 0
+      unit_of_measurement: '°C'
+
+
+    - state_topic: "house/ventilation/whr930/return_air_level"
+      name: "WTW Return Air Level"
+      qos: 0
+      unit_of_measurement: '%'
+
+    - state_topic: "house/ventilation/whr930/supply_air_level"
+      name: "WTW Supply Air Level"
+      qos: 0
+      unit_of_measurement: '%'
+
+    - state_topic: "house/ventilation/whr930/ventilation_level"
+      name: "WTW Ventilation Level"
+      qos: 0
+
+    - state_topic: "house/ventilation/whr930/intake_fan_active"
+      name: "WTW Intake Fan Active"
+      qos: 0
+
+
+    - state_topic: "house/ventilation/whr930/intake_fan_speed"
+      name: "WTW Intake Fan Speed"
+      qos: 0
+      unit_of_measurement: '%'
+
+    - state_topic: "house/ventilation/whr930/exhaust_fan_speed"
+      name: "WTW Exhaust Fan Speed"
+      qos: 0
+      unit_of_measurement: '%'
+
+
+
+    - state_topic: "house/ventilation/whr930/valve_bypass_percentage"
+      name: "WTW Bypass %"
+      qos: 0
+      unit_of_measurement: '%'
+
+    - state_topic: "house/ventilation/whr930/valve_preheating"
+      name: "WTW Valve Preheating"
+      qos: 0
+
+    - state_topic: "house/ventilation/whr930/bypass_motor_current"
+      name: "WTW Bypass motor current"
+      qos: 0
+
+    - state_topic: "house/ventilation/whr930/preheating_motor_current"
+      name: "WTW Preheating motor current"
+      qos: 0
+
+
+    - state_topic: "house/ventilation/whr930/bypass_factor"
+      name: "WTW Bypass Factor"
+      qos: 0
+
+    - state_topic: "house/ventilation/whr930/bypass_step"
+      name: "WTW Bypass Step"
+      qos: 0
+
+    - state_topic: "house/ventilation/whr930/bypass_correction"
+      name: "WTW Bypass Correction"
+      qos: 0
+
+    - state_topic: "house/ventilation/whr930/summermode"
+      name: "WTW Summer mode"
+      qos: 0
+
+```


### PR DESCRIPTION
I added the new mqtt configuration in the readme file, the old one will stop working from version 2022.12